### PR TITLE
Update train.py

### DIFF
--- a/lib/fast_rcnn/train.py
+++ b/lib/fast_rcnn/train.py
@@ -172,6 +172,9 @@ class SolverWrapper(object):
 
         last_snapshot_iter = -1
         timer = Timer()
+        
+        assert restore_iter < max_iters, 'You should set max_steps bigger!'
+        
         # for iter in range(max_iters):
         for iter in range(restore_iter, max_iters):
             timer.tic()


### PR DESCRIPTION
Python will not check if max_iters is bigger than restore_iter in the statement 'for iter in range(restore_iter, max_iters)', add this assertation to prevent this happen